### PR TITLE
Update SqlRunnerTaskAdditionalFields.php

### DIFF
--- a/Classes/Scheduler/SqlRunner/SqlRunnerTaskAdditionalFields.php
+++ b/Classes/Scheduler/SqlRunner/SqlRunnerTaskAdditionalFields.php
@@ -102,7 +102,7 @@ class Tx_PtExtbase_Scheduler_SqlRunner_SqlRunnerTaskAdditionalFields implements 
     {
         $view = GeneralUtility::makeInstance('TYPO3\CMS\Fluid\View\StandaloneView'); /** @var \TYPO3\CMS\Fluid\View\StandaloneView $view */
         $view->setTemplatePathAndFilename(GeneralUtility::getFileAbsFileName('EXT:pt_extbase/Resources/Private/Templates/Scheduler/SqlRunner/TaskAdditionalFields.html'));
-        $view->setPartialRootPath(GeneralUtility::getFileAbsFileName('EXT:pt_extbase/Resources/Private/Partials'));
+        $view->setPartialRootPaths([GeneralUtility::getFileAbsFileName('EXT:pt_extbase/Resources/Private/Partials')]);
         return $view;
     }
 


### PR DESCRIPTION
Hello! 
In TYPO3 v8 i always got an error when adding a scheduler task.
Call to undefined method TYPO3\CMS\Fluid\View\StandaloneView::setPartialRootPath() 

That's because the method now is called  setPartialRootPaths and requires an array.
I've changed it already so that it works at least.